### PR TITLE
[Fix #11] Make it possible to review forge PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,13 @@ index 58baa4b..eae7707 100644
  [[try-the-wrapper-libraries-first]]
 ```
 
-Once done, you can submit your review with one of `github-review-approve`, `github-review-comment` and `github-review-reject`.
+Once done, you can submit your review with one of `github-review-approve`, `github-review-comment`, and `github-review-reject`.
+
+## Usage with Forge
+
+You can use `github-review` with `forget`(https://github.com/magit/forge).
+When your cursor is over a pull request, you can call `github-review-forge-pr-at-point` to start a code
+review.
 
 ## Installation
 

--- a/github-review.el
+++ b/github-review.el
@@ -496,11 +496,9 @@ Gets the PR diff, object, top level comments, and code reviews."
                          (github-review-a-assoc 'object v)
                          (github-review-a-assoc 'chain chain))))))))
 
-;;;###autoload
-(defun github-review-start (url)
+
+(defun github-review-start-internal (pr-alist)
   "Start review given PR URL."
-  (interactive "sPR URL: ")
-  (let* ((pr-alist (github-review-pr-from-url url)))
     (github-review-chain-calls
      pr-alist
      ;; Callback when done
@@ -510,7 +508,30 @@ Gets the PR diff, object, top level comments, and code reviews."
         (github-review-format-diff ctx)))
 
      (github-review-chain)
-     )))
+     ))
+
+;;;###autoload
+(defun github-review-forge-pr-at-point ()
+  "Review the forge pull request at point."
+  (interactive)
+  (let* ((pullreq (forge-pullreq-at-point))
+         (repo (forge-get-repository pullreq))
+         (owner (oref repo owner))
+         (name (oref repo name))
+         (number (oref pullreq number))
+         (pr-alist (-> (github-review-a-empty)
+                       (github-review-a-assoc 'owner owner)
+                       (github-review-a-assoc 'repo  name)
+                       (github-review-a-assoc 'num   number))))
+         (github-review-start-internal pr-alist)))
+
+;;;###autoload
+(defun github-review-start (url)
+  "Start review given PR URL."
+  (interactive "sPR URL: ")
+  (let* ((pr-alist (github-review-pr-from-url url)))
+    (github-review-start-internal pr-alist)))
+
 
 ;;;###autoload
 (defun github-review-approve ()


### PR DESCRIPTION
#### Summary

This PR adds a new entry-point (interactive function): `github-review-forge-pr-at-point`. When on a forge pull request, calling this new function will open the pull request with `github-review`.

#### Test Plan
- [X] Tested on a couple PR on a test repo
- [X] Verified that starting a code review from a URL is not broken
- [X] CI