### PR TITLE
Fix #22 review feedback displayed in reverse order

### DIFF
--- a/github-review.el
+++ b/github-review.el
@@ -349,7 +349,7 @@ ACC is an alist accumulating parsing state."
     (if (equal nil merged-comments)
         `((body . ,parsed-body))
       `((body . ,parsed-body)
-        (comments . ,(-map #'github-review-normalize-comment merged-comments))))))
+        (comments . ,(reverse (-map #'github-review-normalize-comment merged-comments)))))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Buffer interactions ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/github-review-test.el
+++ b/test/github-review-test.el
@@ -139,11 +139,11 @@ index 58baa4b..eae7707 100644
     (defconst complex-review-expected
       '((body . "This is a global comment at the top of the file\nwith multiple\nlines")
         (comments
-         ((position . 6)
-          (body . "Some other comment inline")
-          (path . "content/reference/google-closure-library.adoc"))
          ((position . 5)
           (body . "And a comment inline about\na specific line\n```with some\ncode```")
+          (path . "content/reference/google-closure-library.adoc"))
+         ((position . 6)
+          (body . "Some other comment inline")
           (path . "content/reference/google-closure-library.adoc")))))
 
     (describe "github-review-parse-review-lines"


### PR DESCRIPTION
## Summary
This should fix issue #22 by ensuring the comments are submitted in the right order (top to bottom)

## Test Plan 
- [X] Updated unit tests suite
- [X] Ran tests locally