### PR TITLE
Fix issue #30 Don't error out when reviewing code which use "--" for comments

### DIFF
--- a/github-review.el
+++ b/github-review.el
@@ -243,6 +243,10 @@ For an example of how to use it, look at the tests"
   "Return t if L, a string, is a comment from previous review."
   (string-prefix-p "~ " l))
 
+(defun github-review-is-start-of-file-hunk? (l)
+  "Return t if L, a string that start with 'diff' marking the start of a file hunk."
+  (string-prefix-p "diff" l))
+
 (defun github-review-file-path (l)
   "Extract the file path in L, a string.
 L should looks like +++ b/content/reference/google-closure-library.adoc"
@@ -309,8 +313,8 @@ ACC is an alist accumulating parsing state."
       (github-review-a-assoc acc 'pos 0))
 
      ;; Start of file
-     ((github-review-non-null-filename-hunk-line? l)
-      (github-review-a-assoc (github-review-a-assoc acc 'pos nil) 'path (github-review-file-path l)))
+     ((and top-level? (github-review-non-null-filename-hunk-line? l)
+      (github-review-a-assoc (github-review-a-assoc acc 'pos nil) 'path (github-review-file-path l))))
 
      ;; Global Comments
      ((and top-level? (github-review-comment? l))
@@ -330,6 +334,9 @@ ACC is an alist accumulating parsing state."
             (github-review-a-assoc 'path path)
             (github-review-a-assoc 'body (github-review-comment-text l)))
         comments)))
+
+     ;; Header before the filenames, restart the position
+     ((github-review-is-start-of-file-hunk? l) (github-review-a-assoc acc 'pos nil))
 
      ;; Any other line in a file
      (in-file? (github-review-a-assoc acc 'pos (+ 1 pos)))

--- a/makefile
+++ b/makefile
@@ -1,7 +1,10 @@
-.PHONY: ci local
+.PHONY: ci local test
 ci:
 	cask upgrade-cask
 	cask install
+	cask exec buttercup -L test/github-review-test.el
+
+test:
 	cask exec buttercup -L test/github-review-test.el
 
 # Run the tests locally

--- a/test/github-review-test.el
+++ b/test/github-review-test.el
@@ -70,6 +70,59 @@ index 8ad537d..0000000
           (body . "Comment test")
           (path . "bar")))))
 
+    (defconst example-review-deleted-comment-haskell "# comment test
+~ remove bad
+~
+~
+diff --git a/bar b/bar
+deleted file mode 100644
+index 8ad537d..0000000
+--- a/bar
++++ /dev/null
+@@ -1,5 +0,0 @@
+--- This is a comment
+-dsadasdsad
+-sadasdasdas
+-as
+-
+# Comment test
+diff --git a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+index 9eced0230..4512bb335 100644
+--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
++++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+@@ -47,8 +47,6 @@ import Hledger.Reports.BalanceReport
+ --
+ --   * the full account name
+ --
+---   * the leaf account name
+---
+ --   * the account's depth
+# here too
+ --
+ --   * A list of amounts, one for each column.
+@@ -60,8 +58,8 @@ import Hledger.Reports.BalanceReport
+ -- 3. the column totals, and the overall grand total (or zero for
+ -- cumulative/historical reports) and grand average.
+
+-type MultiBalanceReport    = PeriodicReport AccountLeaf MixedAmount
+-type MultiBalanceReportRow = PeriodicReportRow AccountLeaf MixedAmount
++type MultiBalanceReport    = PeriodicReport AccountName MixedAmount
++type MultiBalanceReportRow = PeriodicReportRow AccountName MixedAmount
+
+ -- type alias just to remind us which AccountNames might be depth-clipped, below.
+ type ClippedAccountName = AccountName
+")
+
+    (defconst expected-review-deleted-comment-haskell
+      '((body . "comment test")
+        (comments
+         ((position . 5)
+          (body . "Comment test")
+          (path . "bar"))
+         ((position . 6)
+          (body . "here too")
+          (path . "hledger-lib/Hledger/Reports/MultiBalanceReport.hs")))))
+
     (defconst examplediff "# This is a global comment at the top of the file
 # with multiple
 # lines
@@ -173,6 +226,9 @@ index 58baa4b..eae7707 100644
       (it "can parse a code review with deleted files"
         (let* ((actual (github-review-parse-review-lines (split-string example-review-deleted-file "\n"))))
           (expect actual :to-equal expected-review-deleted-file)))
+      (it "can parse a code review with a removed comment in haskell"
+        (let* ((actual (github-review-parse-review-lines (split-string example-review-deleted-comment-haskell "\n"))))
+          (expect actual :to-equal expected-review-deleted-comment-haskell)))
       (it "can parse a code review with previous comments but ignores it"
         (let* ((actual (github-review-parse-review-lines (split-string example-previous-comments "\n"))))
           (expect actual :to-equal complex-review-expected-no-comment-on-zeroth-and-first-line)))))


### PR DESCRIPTION
Before this change, comments starting with --, like it is the case in
Haskell would confuse github-review if they are deleted. After this
change it is no longer the case.
Concretely, the parsing logic changes to:
- Only look at --- and +++ when they happen at the top level of a
review (pos is not net)
- Reset the pos to nil when we hit a line that starts with `diff` to
indicate that we are at the top level again

- [X] Took a partial diff from hledger a haskell project and added comments
in multiple parts of it with multiple files and multiple comments
deleted. Added a unit test for it.

FYI @symbiont-sam-halliday who reported the issue and
@matthew-piziak who reacted on the issue