### PR TITLE
Fix #29 Infer ApiHost based on the PR at point

### DIFF
--- a/github-review.el
+++ b/github-review.el
@@ -114,6 +114,9 @@ PR-ALIST is an alist represenging the PR"
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Communication with GitHub ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(defun github-review-api-host (pr-alist)
+  "Return the api host for a PR-ALIST."
+  (or (github-review-a-get pr-alist 'apihost) github-review-host))
 
 (defun github-review-get-pr (pr-alist needs-diff callback)
   "Get a pull request or its diff.
@@ -125,7 +128,7 @@ CALLBACK to call back when done."
              :unpaginate t
              :headers (if needs-diff github-review-diffheader '())
              :auth 'github-review
-             :host github-review-host
+             :host (github-review-api-host pr-alist)
              :callback callback
              :errorback (lambda (&rest _) (message "Error talking to GitHub"))))
 
@@ -148,7 +151,7 @@ CALLBACK will be called back when done"
              nil
              :auth 'github-review
              :payload review
-             :host github-review-host
+             :host (github-review-api-host pr-alist)
              :errorback (lambda (&rest _) (message "Error talking to GitHub"))
              :callback callback))
 
@@ -159,7 +162,7 @@ CALLBACK will be called back when done"
   (ghub-get (github-review-format-pr-url 'get-inline-comments pr-alist)
             nil
             :auth 'github-review
-            :host github-review-host
+            :host (github-review-api-host pr-alist)
             :errorback (lambda (&rest _) (message "Error talking to GitHub"))
             :callback callback))
 
@@ -170,7 +173,7 @@ CALLBACK will be called back when done"
   (ghub-get (github-review-format-pr-url 'get-review-comments pr-alist)
             nil
             :auth 'github-review
-            :host github-review-host
+            :host (github-review-api-host pr-alist)
             :errorback (lambda (&rest _) (message "Error talking to GitHub"))
             :callback callback))
 
@@ -181,7 +184,7 @@ CALLBACK will be called back when done"
   (ghub-get (github-review-format-pr-url 'get-issue-comments pr-alist)
             nil
             :auth 'github-review
-            :host github-review-host
+            :host (github-review-api-host pr-alist)
             :errorback (lambda (&rest _) (message "Error talking to GitHub"))
             :callback callback))
 
@@ -525,10 +528,12 @@ Gets the PR diff, object, top level comments, and code reviews."
          (repo (forge-get-repository pullreq))
          (owner (oref repo owner))
          (name (oref repo name))
+         (apihost (oref repo apihost))
          (number (oref pullreq number))
          (pr-alist (-> (github-review-a-empty)
                        (github-review-a-assoc 'owner owner)
                        (github-review-a-assoc 'repo  name)
+                       (github-review-a-assoc 'apihost apihost)
                        (github-review-a-assoc 'num   number))))
          (github-review-start-internal pr-alist)))
 

--- a/test/github-review-test.el
+++ b/test/github-review-test.el
@@ -336,6 +336,12 @@ index 58baa4b..eae7707 100644
             (github-review-start "https://github.com/charignon/github-review/pull/6")
             (expect diff :to-equal simple-context-expected-review)))))))
 
+(describe "Api host computation"
+  (it "defaults to api.github.com"
+    (expect (github-review-api-host (github-review-a-empty)) :to-equal "api.github.com"))
+  (it "can be overriden"
+    (expect (github-review-api-host (-> (github-review-a-empty) (github-review-a-assoc 'apihost "api.github.biz"))) :to-equal "api.github.biz")))
+
 (provide 'github-review-test)
 
 ;;; github-review-test.el ends here


### PR DESCRIPTION
#### Summary
This fixes issue #29 by leveraging the `apihost` field available in the forge repository object.

#### Test Plan 
- [X] Added a unit test for the api host computation
- [X] Manually tested in ielm what forge sets for the API host looks correct