### PR TITLE
Fix issue #21 Expand forge pr at point support to support forge-topic-mode

### DIFF
--- a/github-review.el
+++ b/github-review.el
@@ -521,7 +521,7 @@ Gets the PR diff, object, top level comments, and code reviews."
 (defun github-review-forge-pr-at-point ()
   "Review the forge pull request at point."
   (interactive)
-  (let* ((pullreq (forge-pullreq-at-point))
+  (let* ((pullreq (or (forge-pullreq-at-point) (forge-current-topic)))
          (repo (forge-get-repository pullreq))
          (owner (oref repo owner))
          (name (oref repo name))


### PR DESCRIPTION
#### Summary
With this change, one can run `github-review-forge-pr-at-point` to start a review from within the forge topic mode, that is when browsing a PR with forge.

#### Test Plan 
- [X] Manually tested