### PR TITLE
Fetch top level comments and reviews comments by default

### DIFF
--- a/github-review.el
+++ b/github-review.el
@@ -56,7 +56,7 @@
   :group 'github-review
   :type 'string)
 
-(defcustom github-review-fetch-top-level-and-review-comments nil
+(defcustom github-review-fetch-top-level-and-review-comments t
   "If t, fetch the top level and review comments."
   :group 'github-review
   :type 'boolean)


### PR DESCRIPTION
This behavior has been behind a flag for a while and I haven't seen
issues with it. I am making it the default as this is what people
probably want (I assume that the more context on a PR, the better)