### PR TITLE
Switch to using deferred and remove custom async framework

### DIFF
--- a/github-review.el
+++ b/github-review.el
@@ -125,13 +125,13 @@ PR-ALIST is an alist representing a PR,
 NEEDS-DIFF t to return a diff nil to return the pr object
 CALLBACK to call back when done."
   (ghub-get (github-review-format-pr-url 'get-pr pr-alist)
-             nil
-             :unpaginate t
-             :headers (if needs-diff github-review-diffheader '())
-             :auth 'github-review
-             :host (github-review-api-host pr-alist)
-             :callback callback
-             :errorback (lambda (&rest _) (message "Error talking to GitHub"))))
+            nil
+            :unpaginate t
+            :headers (if needs-diff github-review-diffheader '())
+            :auth 'github-review
+            :host (github-review-api-host pr-alist)
+            :callback callback
+            :errorback (lambda (&rest _) (message "Error talking to GitHub"))))
 
 (defun github-review-get-pr-object (pr-alist callback)
   "Get a pr object given PR-ALIST an alist representing a PR.
@@ -151,8 +151,8 @@ return a deferred object"
   (let ((d (deferred:new #'identity)))
     (if needs-diff
         (github-review-get-pr-diff pr-alist (apply-partially (lambda (d v &rest _)  (deferred:callback-post d v)) d))
-        (github-review-get-pr-object pr-alist (apply-partially (lambda (d v &rest _)  (deferred:callback-post d v)) d)))
-      d))
+      (github-review-get-pr-object pr-alist (apply-partially (lambda (d v &rest _)  (deferred:callback-post d v)) d)))
+    d))
 
 
 (defun github-review-post-review (pr-alist review callback)
@@ -309,7 +309,7 @@ ACC is an alist accumulating parsing state."
 
      ;; Start of file
      ((and top-level? (github-review-non-null-filename-hunk-line? l)
-      (github-review-a-assoc (github-review-a-assoc acc 'pos nil) 'path (github-review-file-path l))))
+           (github-review-a-assoc (github-review-a-assoc acc 'pos nil) 'path (github-review-file-path l))))
 
      ;; Global Comments
      ((and top-level? (github-review-comment? l))
@@ -449,28 +449,28 @@ See ‘github-review-start’ for more information"
                      (string= (github-review-a-get x 'body) ""))
                    (github-review-a-get ctx 'reviews)))
          (diff (-> ctx (github-review-a-get 'diff) (github-review-a-get 'message))))
-  (concat
-   (github-review-to-comments title)
-   "\n~"
-   "\n"
-   ;; Github PR body contains \n\r for new lines
-   (github-review-to-comments (s-replace "\r" "" body))
-   "\n"
-   (when top-level-comments
-     (concat (s-join
-              "\n"
-              (-map
-               #'github-review-to-comments
-               (-map #'github-review-format-top-level-comment top-level-comments)))
-             "\n"))
-   (when reviews
-     (concat (s-join
-              "\n"
-              (-map
-               #'github-review-to-comments
-               (-map #'github-review-format-review reviews)))
-             "\n"))
-   diff)))
+    (concat
+     (github-review-to-comments title)
+     "\n~"
+     "\n"
+     ;; Github PR body contains \n\r for new lines
+     (github-review-to-comments (s-replace "\r" "" body))
+     "\n"
+     (when top-level-comments
+       (concat (s-join
+                "\n"
+                (-map
+                 #'github-review-to-comments
+                 (-map #'github-review-format-top-level-comment top-level-comments)))
+               "\n"))
+     (when reviews
+       (concat (s-join
+                "\n"
+                (-map
+                 #'github-review-to-comments
+                 (-map #'github-review-format-review reviews)))
+               "\n"))
+     diff)))
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; User facing API ;;
@@ -493,21 +493,21 @@ See ‘github-review-start’ for more information"
     (deferred:nextc it
       (lambda (x)
         (let* ((diff (-> x (elt 0)))
-              (pr-object (-> x (elt 1)))
-              (comms (github-review-a-get pr-object 'comments))
-              (review_comments (github-review-a-get pr-object 'review_comments))
-              (issues-comments (when (and (> comms 0) github-review-fetch-top-level-and-review-comments) (-> x (elt 2))))
-              (reviews (when (and (> review_comments 0) github-review-fetch-top-level-and-review-comments) github-review-fetch-top-level-and-review-comments (-> x (elt 3)))))
-           (github-review-save-diff
-            pr-alist
-            (github-review-format-diff (-> (github-review-a-empty)
-                       (github-review-a-assoc 'diff diff)
-                       (github-review-a-assoc 'object pr-object)
-                       (github-review-a-assoc 'top-level-comments issues-comments)
-                       (github-review-a-assoc 'reviews reviews)))))))
+               (pr-object (-> x (elt 1)))
+               (comms (github-review-a-get pr-object 'comments))
+               (review_comments (github-review-a-get pr-object 'review_comments))
+               (issues-comments (when (and (> comms 0) github-review-fetch-top-level-and-review-comments) (-> x (elt 2))))
+               (reviews (when (and (> review_comments 0) github-review-fetch-top-level-and-review-comments) github-review-fetch-top-level-and-review-comments (-> x (elt 3)))))
+          (github-review-save-diff
+           pr-alist
+           (github-review-format-diff (-> (github-review-a-empty)
+                                          (github-review-a-assoc 'diff diff)
+                                          (github-review-a-assoc 'object pr-object)
+                                          (github-review-a-assoc 'top-level-comments issues-comments)
+                                          (github-review-a-assoc 'reviews reviews)))))))
     (deferred:error it
-    (lambda (err)
-      (message "Got an error from the GitHub API!")))))
+      (lambda (err)
+        (message "Got an error from the GitHub API!")))))
 
 
 ;;;###autoload
@@ -525,7 +525,7 @@ See ‘github-review-start’ for more information"
                        (github-review-a-assoc 'repo  name)
                        (github-review-a-assoc 'apihost apihost)
                        (github-review-a-assoc 'num   number))))
-         (github-review-start-internal pr-alist)))
+    (github-review-start-internal pr-alist)))
 
 ;;;###autoload
 (defun github-review-start (url)

--- a/github-review.el
+++ b/github-review.el
@@ -507,7 +507,7 @@ See ‘github-review-start’ for more information"
                                           (github-review-a-assoc 'reviews reviews)))))))
     (deferred:error it
       (lambda (err)
-        (message "Got an error from the GitHub API!")))))
+        (message "Got an error from the GitHub API %s!" err)))))
 
 
 ;;;###autoload

--- a/test/github-review-test.el
+++ b/test/github-review-test.el
@@ -273,49 +273,6 @@ index 58baa4b..eae7707 100644
       (it "can format a diff with top level comments and review"
         (expect (github-review-format-diff context-with-tl-comments)
                 :to-equal expected-review-tl-comment))))
-
-  (describe "callback logic"
-
-    (describe "github-review-chain-calls"
-      (it "can execute a chain of one function"
-        (let ((res 8))
-          (github-review-chain-calls
-           ;; No argument
-           nil
-
-           ;; Final callback set res to the content of the 'foo key
-           (lambda (ctx)
-             (setq res (github-review-a-get ctx 'foo)))
-
-           ;; Function simulate an api call, takes arg and callback
-           ;; and populate the 'foo key with the result
-           '(((function . (lambda (arg cb) (funcall cb 3)))
-              (key . foo))))
-          (expect res :to-equal 3)))
-      (it "can execute a chain of two functions"
-        (let ((res 8))
-          (github-review-chain-calls
-           ;; No argument
-           nil
-
-           ;; Final callback set res to the content of the 'foo key
-           (lambda (ctx)
-             (setq res (github-review-a-get ctx 'foo)))
-
-           '(
-             ;; Function simulate an api call, takes arg and callback
-             ;; and populate the 'foo key with the result
-             ((function . (lambda (arg cb) (funcall cb 3)))
-              (key . foo))
-             ;; Function increment the content of the key foo
-             ((function . (lambda (arg cb) (funcall cb 42)))
-              (callback . (lambda (arg ctx)
-                            (github-review-a-assoc ctx
-                                                   'foo
-                                                   (+ 1
-                                                      (github-review-a-get ctx 'foo))))))))
-          (expect res :to-equal 4)))))
-
   (describe "entrypoints"
     (describe "github-review-start"
       :var (github-review-save-diff
@@ -355,7 +312,7 @@ index 58baa4b..eae7707 100644
                              (review_comments . 0)
                              (title . "title\nin\nthree\nlines"))))))
         (it "can render a diff"
-          (github-review-start "https://github.com/charignon/github-review/pull/6")
+          (deferred:sync! (github-review-start "https://github.com/charignon/github-review/pull/6"))
           (expect diff :to-equal simple-context-expected-review)))
 
       (describe "with top level comments"
@@ -369,7 +326,7 @@ index 58baa4b..eae7707 100644
                              (title . "title\nin\nthree\nlines"))))))
         (it "can render a diff"
           (let ((github-review-fetch-top-level-and-review-comments t))
-            (github-review-start "https://github.com/charignon/github-review/pull/6")
+            (deferred:sync! (github-review-start "https://github.com/charignon/github-review/pull/6"))
             (expect diff :to-equal expected-review-tl-comment))))
 
       (describe "with review that has no top level comment"
@@ -389,7 +346,7 @@ index 58baa4b..eae7707 100644
                              (title . "title\nin\nthree\nlines"))))))
         (it "does not show it"
           (let ((github-review-fetch-top-level-and-review-comments t))
-            (github-review-start "https://github.com/charignon/github-review/pull/6")
+            (deferred:sync! (github-review-start "https://github.com/charignon/github-review/pull/6"))
             (expect diff :to-equal simple-context-expected-review)))))))
 
 (describe "Api host computation"


### PR DESCRIPTION
#### Summary
This PR removes the custom async logic that was there and instead switches to using deferred.el. This will (1) Improve performance as we now make more GitHub API requests calls in parallel and (2) improve maintainability by using widely accepted idioms for asynchronous work in elisp and reduce surprises for contributors.

NOTE: In the long run this will make it easier for me to add gitlab support on top of this.

#### Test Plan 
- [X] Modified the existing tests to exercise the new ways of doing asynchronous processing
- [X] Manually tested that fetching a diff still works end to end

I will be running this specific version for a week to see how it goes. If anyone feels like reviewing the in the next week, I will leave the PR open, otherwise will merge it. Maybe @seanfarley or @parhamdoustdar or @agzam want to take a look?