### PR TITLE
Make review consistent even if new code is pushed

### DIFF
--- a/test/github-review-test.el
+++ b/test/github-review-test.el
@@ -240,8 +240,9 @@ index 58baa4b..eae7707 100644
       (it "can parse fname and infer pr name"
         (expect
          (a-equal
-          (github-review-pr-from-fname "/tmp/charignon___testgheapi___2.diff")
-          '((num . "2")
+          (github-review-pr-from-fname "/tmp/charignon___testgheapi___2___60b73b28cc8b1b97ae5474b799219388952b9fc7.diff")
+          '((sha . "60b73b28cc8b1b97ae5474b799219388952b9fc7")
+            (num . "2")
             (repo . "testgheapi")
             (owner . "charignon"))))))
 


### PR DESCRIPTION
#### Summary
Before this change code review was applied to the latest commit assuming
that no code had change since it was fetched. After this change the code
review is applied to the correct commit (the one that was pulled), and
even if the PR changes during review the comments end up in the right
place.

#### Test Plan
- [x] Manual test
- [x] CI
- [x] Update architecture diagram