### PR TITLE
Improve type and default for github-review-review-folder

### DIFF
--- a/github-review.el
+++ b/github-review.el
@@ -52,7 +52,7 @@
 (defcustom github-review-review-folder temporary-file-directory
   "Folder in which to store the code review files."
   :group 'github-review
-  :type 'string)
+  :type 'directory)
 
 (defcustom github-review-host "api.github.com"
   "Host for the GitHub api."

--- a/github-review.el
+++ b/github-review.el
@@ -49,7 +49,7 @@
   "Write and submit GitHub code reviews from within Emacs."
   :group 'tools)
 
-(defcustom github-review-review-folder "/tmp"
+(defcustom github-review-review-folder temporary-file-directory
   "Folder in which to store the code review files."
   :group 'github-review
   :type 'string)


### PR DESCRIPTION
* temporary-file-directory is the better default
* `'directory` is more accurate than `'string` as a type