### PR TITLE
Replying to inline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ machine api.github.com login yourlogin^github-review password MYTOKENGOESHERE
 If you use GitHub Enterprise, you can use the `github-review-host` custom variable to
 configure the endpoint of your GitHub Enterprise installation, this should look like `api.git.mycompany.com`.
 
+- By default, `github-review` fetches only top level comments in a pull request.
+  You can set `github-review-view-comments-in-code-lines` to `t` to also fetch
+  comments made between code lines.
+
 ## Notice
 
 *I am providing code in the repository to you under an open source license. Because this is my personal repository, the license you receive to my

--- a/github-review.el
+++ b/github-review.el
@@ -343,7 +343,7 @@ This function infers the PR name based on the current filename"
   (let-alist review
     (format "Reviewed by @%s[%s]: %s" .author.login .state .bodyText)))
 
-(setq github-review-comment-pos ())
+(setq github-review-comment-pos nil)
 
 (defun github-review-place-review-comments (gitdiff review)
   (if (not (a-get-in review (list 'comments 'nodes)))
@@ -362,14 +362,13 @@ This function infers the PR name based on the current filename"
                (let* ((original-pos (a-get comment 'originalPosition))
                       (adjusted-pos (+ original-pos
                                        default-shift-pos
-                                       (or (a-get github-review-comment-pos original-pos) 0)))
+                                       (or github-review-comment-pos 0)))
                       (comment-lines (split-string (a-get comment 'bodyText) "\n"))
                       (diff-splitted (-split-at adjusted-pos acc-diff)))
 
-                 (push (cons original-pos (+ (or (a-get github-review-comment-pos original-pos) 0)
-                                             (length comment-lines)
-                                             (length body-lines)))
-                       github-review-comment-pos)
+                 (setq github-review-comment-pos (+ (or github-review-comment-pos 0)
+                                                    (length comment-lines)
+                                                    (length body-lines)))
                  (-concat
                   (-first-item diff-splitted)
                   (list ""
@@ -393,9 +392,8 @@ This function infers the PR name based on the current filename"
 
 (defun github-review-format-diff (gitdiff pr)
   "Formats a GITDIFF and PR to save it for review."
-  (message "AQUI sim")
   (let-alist pr
-    (setq github-review-comment-pos ())
+    (setq github-review-comment-pos nil)
     (concat
      (github-review-to-comments .title)
      "\n~"

--- a/github-review.el
+++ b/github-review.el
@@ -60,6 +60,10 @@
   :group 'github-review
   :type 'string)
 
+(defcustom github-review-view-comments-in-code-lines nil
+  "Flag to enable displaying comments in code lines."
+  :group 'github-review)
+
 (defconst github-review-diffheader '(("Accept" . "application/vnd.github.v3.diff"))
   "Header for requesting diffs from GitHub.")
 
@@ -419,12 +423,13 @@ This function infers the PR name based on the current filename"
                  #'github-review-to-comments
                  (-map #'github-review-format-review reviews)))
                "\n"))
-     "\n"
-     (-reduce-from
-      (lambda (acc-gitdiff node)
-        (github-review-place-review-comments acc-gitdiff node))
-      (a-get gitdiff 'message)
-      .reviews.nodes))))
+     (if github-review-view-comments-in-code-lines
+         (-reduce-from
+          (lambda (acc-gitdiff node)
+            (github-review-place-review-comments acc-gitdiff node))
+          (a-get gitdiff 'message)
+          .reviews.nodes)
+       (a-get gitdiff 'message)))))
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; User facing API ;;

--- a/github-review.el
+++ b/github-review.el
@@ -331,12 +331,12 @@ This function infers the PR name based on the current filename"
 
 (defun github-review-to-comments (text)
   "Convert TEXT, a string to a string where each line is prefixed by ~."
-  (s-join "\n" (-map (lambda (x) (concat "~ " x)) (s-split "\n" text))))
+  (s-join "\n" (-concat (list " ") (-map (lambda (x) (concat "~ " x)) (s-split "\n" text)))))
 
 (defun github-review-format-top-level-comment (com)
   "Format a top level COM objectto string."
   (let-alist com
-    (format "@%s: %s" .author.login .bodyText)))
+    (format "Commented by @%s: %s" .author.login .bodyText)))
 
 (defun github-review-format-review (review)
   "Format a REVIEW object to string."

--- a/github-review.el
+++ b/github-review.el
@@ -350,7 +350,10 @@ This function infers the PR name based on the current filename"
         (format "Reviewed by @%s[%s]: %s" .author.login .state .bodyText)
       "")))
 
-(setq github-review-comment-pos nil)
+(defvar github-review-comment-pos nil
+  "Variable to count how many comments in code lines were added in the diff.
+This is necessary to adjust the new comments to the correct position in the diff given that
+Github API provides only the originalPosition in the query.")
 
 (defun github-review-place-review-comments (gitdiff review)
   (if (not (a-get-in review (list 'comments 'nodes)))

--- a/github-review.el
+++ b/github-review.el
@@ -352,12 +352,12 @@ This function infers the PR name based on the current filename"
 
 (defun github-review-to-comments (text)
   "Convert TEXT, a string to a string where each line is prefixed by ~."
-  (s-join "\n" (-concat (list " ") (-map (lambda (x) (concat "~ " x)) (s-split "\n" text)))))
+  (s-join "\n" (-map (lambda (x) (concat "~ " x)) (s-split "\n" text))))
 
 (defun github-review-format-top-level-comment (com)
   "Format a top level COM objectto string."
   (let-alist com
-    (format "Commented by @%s: %s" .author.login .bodyText)))
+    (format "@%s: %s" .author.login .bodyText)))
 
 (defun github-review-format-review (review)
   "Format a REVIEW object to string."
@@ -394,11 +394,12 @@ Github API provides only the originalPosition in the query.")
 
                  (setq github-review-comment-pos (+ (or github-review-comment-pos 0)
                                                     (length comment-lines)
-                                                    (length body-lines)))
+                                                    (if (string-empty-p body)
+                                                        0
+                                                      (length body-lines))))
                  (-concat
                   (-first-item diff-splitted)
-                  (list ""
-                        (format "~ Reviewed by @%s[%s]: %s" at state
+                  (list (format "~ Reviewed by @%s[%s]: %s" at state
                                 (if (string-empty-p body)
                                     (-first-item comment-lines)
                                   (-first-item body-lines))))

--- a/github-review.el
+++ b/github-review.el
@@ -423,16 +423,7 @@ This function infers the PR name based on the current filename"
       (lambda (acc-gitdiff node)
         (github-review-place-review-comments acc-gitdiff node))
       (a-get gitdiff 'message)
-      .reviews.nodes)
-     ;; (when-let ((reviews (-reject (lambda (x) (string= (a-get x 'body) "")) .reviews.nodes)))
-     ;;   (concat (s-join
-     ;;            "\n"
-     ;;            (-map
-     ;;             #'github-review-to-comments
-     ;;             (-map #'github-review-format-review reviews)))
-     ;;           "\n"))
-     ;; (a-get gitdiff 'message)
-     )))
+      .reviews.nodes))))
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; User facing API ;;

--- a/github-review.el
+++ b/github-review.el
@@ -415,7 +415,6 @@ This function infers the PR name based on the current filename"
                  #'github-review-to-comments
                  (-map #'github-review-format-top-level-comment .comments.nodes)))
                "\n"))
-     "\n"
      (when-let ((reviews (-reject (lambda (x) (string= (a-get x 'body) "")) .reviews.nodes)))
        (concat (s-join
                 "\n"

--- a/github-review.el
+++ b/github-review.el
@@ -120,13 +120,29 @@ return a deferred object"
         nodes { author { login } bodyText }
       }
       reviews(first: 50) {
+        nodes { author { login } bodyText state }
+      } }
+  }
+}" .repo .owner .num))
+          (query-with-comments (format "query {
+  repository(name: \"%s\", owner: \"%s\") {
+    pullRequest(number: %s){
+      headRef { target{ oid } }
+      title
+      bodyText
+      comments(first:50) {
+        nodes { author { login } bodyText }
+      }
+      reviews(first: 50) {
         nodes { author { login } bodyText state
           comments(first: 50)
             { nodes { bodyText originalPosition } }}
       } }
   }
 }" .repo .owner .num)))
-      (ghub-graphql query
+      (ghub-graphql (if github-review-view-comments-in-code-lines
+                        query-with-comments
+                      query)
                     '()
                     :auth 'github-review
                     :host (github-review-api-host pr-alist)

--- a/github-review.el
+++ b/github-review.el
@@ -117,7 +117,8 @@ return a deferred object"
       }
       reviews(first: 50) {
         nodes { author { login } bodyText state
-          comments(first: 50) { nodes { bodyText diffHunk originalPosition } }}
+          comments(first: 50)
+            { nodes { bodyText originalPosition } }}
       } }
   }
 }" .repo .owner .num)))

--- a/github-review.el
+++ b/github-review.el
@@ -444,7 +444,6 @@ This function infers the PR name based on the current filename"
     (deferred:nextc it
       (lambda (x)
         (let-alist (-second-item x)
-
           (github-review-save-diff
            (a-assoc pr-alist 'sha .data.repository.pullRequest.headRef.target.oid)
            (github-review-format-diff (-first-item x) .data.repository.pullRequest)))))

--- a/github-review.el
+++ b/github-review.el
@@ -419,7 +419,6 @@ Github API provides only the originalPosition in the query.")
 (defun github-review-format-diff (gitdiff pr)
   "Formats a GITDIFF and PR to save it for review."
   (let-alist pr
-    (setq github-review-comment-pos nil)
     (concat
      (github-review-to-comments .title)
      "\n~"
@@ -442,11 +441,13 @@ Github API provides only the originalPosition in the query.")
                  (-map #'github-review-format-review reviews)))
                "\n"))
      (if github-review-view-comments-in-code-lines
-         (-reduce-from
-          (lambda (acc-gitdiff node)
-            (github-review-place-review-comments acc-gitdiff node))
-          (a-get gitdiff 'message)
-          .reviews.nodes)
+         (progn
+           (setq github-review-comment-pos nil)
+           (-reduce-from
+            (lambda (acc-gitdiff node)
+              (github-review-place-review-comments acc-gitdiff node))
+            (a-get gitdiff 'message)
+            .reviews.nodes))
        (a-get gitdiff 'message)))))
 
 ;;;;;;;;;;;;;;;;;;;;;

--- a/test/github-review-test.el
+++ b/test/github-review-test.el
@@ -333,9 +333,8 @@ index 58baa4b..eae7707 100644
                           'nodes
                           (list (a-alist 'bodyText "Very interesting change\nwe should move forward"
                                          'originalPosition 2)
-                           (a-alist 'bodyText "Change this code"
-                                         'originalPosition 4)
-                                ))))
+                                (a-alist 'bodyText "Change this code"
+                                         'originalPosition 4)))))
 
     (describe "github-review-format-diff"
       (it "can format a simple diff"


### PR DESCRIPTION
I was able to make this first version work for replying to inline comments, however I need to clear the code and make it more robust. The only thing I noticed that is causing some errors in some pages is that `pos` computed by our algorithm does not always match `originalPosition` returned by Github GraphQL API for a given comment.

In my initial design this is necessary to build a lookup table (`github-review-pos->databaseid`) to index the `databaseID` of the comment that we will be replying to. I will dig more into it, this PR is a working in progress.

This issue seems related to `outdated` information in the PR/review API. The `position` field for some review comments are updated, but others are returned as `null`. :/

Note: This build on top of #79 so commits are duplicated here